### PR TITLE
Modify PVC to use storageClassName

### DIFF
--- a/containers/blockchain/kube-configs/persistent-volume/persistent-volume-claims.yaml
+++ b/containers/blockchain/kube-configs/persistent-volume/persistent-volume-claims.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "ibmc-file-gold"
   name: peer-claim
   labels:
     app: peer-volume
@@ -13,12 +11,11 @@ spec:
   resources:
     requests:
       storage: 20Gi
+  storageClassName: "ibmc-file-gold"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "ibmc-file-gold"
   name: org-ca-claim
   labels:
     app: org-ca-volume
@@ -28,12 +25,11 @@ spec:
   resources:
     requests:
       storage: 20Gi
+  storageClassName: "ibmc-file-gold"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "ibmc-file-gold"
   name: couchdb-claim
   labels:
     app: couchdb-volume
@@ -43,3 +39,4 @@ spec:
   resources:
     requests:
       storage: 20Gi
+  storageClassName: "ibmc-file-gold"


### PR DESCRIPTION
This commit modifies the persistent volume claims to use
storageClassName instead of the annotation. The use of annotation is
still working but will be deprecated in future release of upstream
Kubernetes.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>